### PR TITLE
v2.0.7

### DIFF
--- a/app/models/hyrax/contact_form.rb
+++ b/app/models/hyrax/contact_form.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module Hyrax
+  class ContactForm
+    include ActiveModel::Model
+    attr_accessor :contact_method, :category, :name, :email, :subject, :message
+    validates :email, :category, :name, :subject, :message, presence: true
+    validates :email, format: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i, allow_blank: true
+
+    # - can't use this without ActiveRecord::Base validates_inclusion_of :category, in: self.class.issue_types_for_locale
+
+    # They should not have filled out the `contact_method' field. That's there to prevent spam.
+    def spam?
+      contact_method.present?
+    end
+
+    # Declare the e-mail headers. It accepts anything the mail method
+    # in ActionMailer accepts.
+    # CUBL-CUSTOM: we can only send from a verified email address
+    def headers
+      {
+        subject: "#{Hyrax.config.subject_prefix} #{subject}",
+        to: Hyrax.config.contact_email,
+        from: ENV["EMAIL_FROM"], 
+        reply_to: ENV["EMAIL_REPLY"]
+      }
+    end
+
+    def self.issue_types_for_locale
+      I18n.t('hyrax.contact_form.issue_types').values.select(&:present?)
+    end
+  end
+end

--- a/app/views/hyrax/contact_mailer/contact.html.erb
+++ b/app/views/hyrax/contact_mailer/contact.html.erb
@@ -1,0 +1,8 @@
+Dear IR Scholar Administrator,
+
+<p><%= @contact_form.name %> has submitted a contact form request:</p>
+
+<p>From: <%= %("#{@contact_form.name}" <#{@contact_form.email}>) %></p>
+<p>Issue Type: <%= @contact_form.category %></p>
+<p>Subject: <%= @contact_form.subject %></p>
+<p><%= @contact_form.message %></p>

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -45,7 +45,7 @@ Hyrax.config do |config|
   # config.rendering_predicate = ::RDF::DC.hasFormat
 
   # Email recipient of messages sent via the contact form
-  config.contact_email = ENV['EMAIL_FROM']
+  config.contact_email = ENV['EMAIL_TO']
 
   # Text prefacing the subject entered in the contact form
   # config.subject_prefix = "Contact form:"


### PR DESCRIPTION
Contact Form email issue is fixed by sending email from an email address set via secrets - the user's email is no longer used.  The email content is slightly changed to provide better information from the contact form.
