### PR TITLE
v3.1.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -46,6 +46,8 @@ config/local_env.yml
 
 fits.log
 .vscode/*
+/.ai
+/.junie
 
 rules.log
 log/rules.log

--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ fits.log
 .vscode/*
 .idea
 .ai
+.junie
 
 rules.log
 log/rules.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,9 +107,8 @@ COPY . /data/
 
 RUN cp /data/public/assets/work-*.png /data/public/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png && \
     cp /data/public/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png /data/public/assets/work-a6ad224077dcf8d7342d3f671bab54554d5e2e1b9b1506a25411a840b1c85202.png && \
-    cp /data/public/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png /data/public/assets/work-e8271462ebe82228c43c3ebe6851235c8919bef84a6360d412615e8e48e38f89.png && \
-    mv /data/app/assets/stylesheets/cu_boulder_font.css /data/public/assets/cu_boulder_font.css && \
-    mv /data/app/assets/stylesheets/cu_boulder_branding.css /data/public/assets/cu_boulder_branding.css
+    cp /data/public/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png /data/public/assets/work-e8271462ebe82228c43c3ebe6851235c8919bef84a6360d412615e8e48e38f89.png
+
 
 RUN mkdir -p /opt/fits && \
     curl -fSL -o /opt/fits-1.6.0.zip https://github.com/harvard-lts/fits/releases/download/1.6.0/fits-1.6.0.zip && \

--- a/Gemfile
+++ b/Gemfile
@@ -118,3 +118,5 @@ gem "active-fedora", "~> 13.3"
 gem "sprockets", "= 3.7.2"
 
 gem "ffi", "= 1.17.2"
+
+gem "okcomputer", "~> 1.19"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.21)
+    benchmark (0.5.0)
     bigdecimal (4.0.1)
     bindex (0.8.1)
     blacklight (6.25.0)
@@ -654,6 +655,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
+    okcomputer (1.19.1)
+      benchmark
     omniauth (1.9.2)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -1056,6 +1059,7 @@ DEPENDENCIES
   mini_magick
   minitar-cli
   mysql2
+  okcomputer (~> 1.19)
   omniauth-saml!
   posix-spawn
   puma (~> 3.7)

--- a/app/assets/stylesheets/cu_boulder_branding.css
+++ b/app/assets/stylesheets/cu_boulder_branding.css
@@ -1,16 +1,14 @@
 .samvera-cu-brand {
-    width: 300px;
+    width:300px;
     padding: 5px 15px !important;
     height: 35px !important;
 }
-
 .samvera-cu-brand-department {
-    width: 300px;
-    clear: both;
-    padding: 4px 4px 4px 2px !important;
-    display: block !important;
+    width:300px;
+    clear:both;
+    padding:4px 4px 4px 2px !important;
+    display:block !important;
 }
-
 .collection-highlights img {
     height: 60px;
     width: 60px;
@@ -19,15 +17,8 @@
 body.dashboard {
     margin-top: 43px;
 }
-
-.site-footer {
-    color: white;
-}
-
-.ucb-footer p {
-    margin-bottom: 2px;
-}
-
+.site-footer {color:white;}
+.ucb-footer p {margin-bottom:2px;}
 /* * Global styles
 html { box-sizing: border-box; }
 
@@ -47,208 +38,64 @@ a:active { color: #B71C1C; text-decoration-color: rgba(183, 28, 28, 0.65); -webk
     white-space: nowrap !important;
 }
 
-#print-header {
-    display: none;
-}
+#print-header { display: none; }
 
-.banner-white .header-wrapper, header.white {
-    background: #fff;
-    color: #111111;
-}
+.banner-white .header-wrapper, header.white { background: #fff; color: #111111; }
+.banner-white .header-wrapper a:link, .banner-white .header-wrapper a:visited, .banner-white .header-wrapper a:hover, header.white a:link, header.white a:visited, header.white a:hover { color: #111111; }
+.banner-white .header-wrapper .menu-toggle button, header.white .menu-toggle button { color: #111111; border-color: rgba(128, 128, 128, 0.5); }
+.banner-white .header-wrapper a.search-toggle:link, .banner-white .header-wrapper a.search-toggle:visited, header.white a.search-toggle:link, header.white a.search-toggle:visited { color: #111111; }
 
-.banner-white .header-wrapper a:link, .banner-white .header-wrapper a:visited, .banner-white .header-wrapper a:hover, header.white a:link, header.white a:visited, header.white a:hover {
-    color: #111111;
-}
+.banner-light .header-wrapper, header.light { background: #EEEEEE; color: #111111; }
+.banner-light .header-wrapper a:link, .banner-light .header-wrapper a:visited, .banner-light .header-wrapper a:hover, header.light a:link, header.light a:visited, header.light a:hover { color: #111111; }
+.banner-light .header-wrapper .menu-toggle button, header.light .menu-toggle button { color: #111111; border-color: rgba(128, 128, 128, 0.5); }
+.banner-light .header-wrapper a.search-toggle:link, .banner-light .header-wrapper a.search-toggle:visited, header.light a.search-toggle:link, header.light a.search-toggle:visited { color: #111111; }
 
-.banner-white .header-wrapper .menu-toggle button, header.white .menu-toggle button {
-    color: #111111;
-    border-color: rgba(128, 128, 128, 0.5);
-}
+.banner-dark .header-wrapper, header.dark { background: #424242; color: #fff; }
+.banner-dark .header-wrapper a:link, .banner-dark .header-wrapper a:visited, .banner-dark .header-wrapper a:hover, header.dark a:link, header.dark a:visited, header.dark a:hover { color: #fff; }
+.banner-dark .header-wrapper .menu-toggle button, header.dark .menu-toggle button { color: #fff; border-color: rgba(128, 128, 128, 0.5); }
+.banner-dark .header-wrapper a.search-toggle:link, .banner-dark .header-wrapper a.search-toggle:visited, header.dark a.search-toggle:link, header.dark a.search-toggle:visited { color: #fff; }
 
-.banner-white .header-wrapper a.search-toggle:link, .banner-white .header-wrapper a.search-toggle:visited, header.white a.search-toggle:link, header.white a.search-toggle:visited {
-    color: #111111;
-}
+.banner-black .header-wrapper, header.black { background: #000; color: #fff; }
+.banner-black .header-wrapper a:link, .banner-black .header-wrapper a:visited, .banner-black .header-wrapper a:hover, header.black a:link, header.black a:visited, header.black a:hover { color: #fff; }
+.banner-black .header-wrapper .menu-toggle button, header.black .menu-toggle button { color: #fff; border-color: rgba(128, 128, 128, 0.5); }
+.banner-black .header-wrapper a.search-toggle:link, .banner-black .header-wrapper a.search-toggle:visited, header.black a.search-toggle:link, header.black a.search-toggle:visited { color: #fff; }
 
-.banner-light .header-wrapper, header.light {
-    background: #EEEEEE;
-    color: #111111;
-}
-
-.banner-light .header-wrapper a:link, .banner-light .header-wrapper a:visited, .banner-light .header-wrapper a:hover, header.light a:link, header.light a:visited, header.light a:hover {
-    color: #111111;
-}
-
-.banner-light .header-wrapper .menu-toggle button, header.light .menu-toggle button {
-    color: #111111;
-    border-color: rgba(128, 128, 128, 0.5);
-}
-
-.banner-light .header-wrapper a.search-toggle:link, .banner-light .header-wrapper a.search-toggle:visited, header.light a.search-toggle:link, header.light a.search-toggle:visited {
-    color: #111111;
-}
-
-.banner-dark .header-wrapper, header.dark {
-    background: #424242;
-    color: #fff;
-}
-
-.banner-dark .header-wrapper a:link, .banner-dark .header-wrapper a:visited, .banner-dark .header-wrapper a:hover, header.dark a:link, header.dark a:visited, header.dark a:hover {
-    color: #fff;
-}
-
-.banner-dark .header-wrapper .menu-toggle button, header.dark .menu-toggle button {
-    color: #fff;
-    border-color: rgba(128, 128, 128, 0.5);
-}
-
-.banner-dark .header-wrapper a.search-toggle:link, .banner-dark .header-wrapper a.search-toggle:visited, header.dark a.search-toggle:link, header.dark a.search-toggle:visited {
-    color: #fff;
-}
-
-.banner-black .header-wrapper, header.black {
-    background: #000;
-    color: #fff;
-}
-
-.banner-black .header-wrapper a:link, .banner-black .header-wrapper a:visited, .banner-black .header-wrapper a:hover, header.black a:link, header.black a:visited, header.black a:hover {
-    color: #fff;
-}
-
-.banner-black .header-wrapper .menu-toggle button, header.black .menu-toggle button {
-    color: #fff;
-    border-color: rgba(128, 128, 128, 0.5);
-}
-
-.banner-black .header-wrapper a.search-toggle:link, .banner-black .header-wrapper a.search-toggle:visited, header.black a.search-toggle:link, header.black a.search-toggle:visited {
-    color: #fff;
-}
-
-#branding {
-    position: relative;
-}
+#branding { position: relative; }
 
 /* NEW BRANDING */
-.brand-bar {
-    background: #000;
-    color: #fff;
-    padding: 10px 0px;
-}
+.brand-bar { background: #000; color: #fff; padding: 10px 0px; }
+.brand-bar a:link, .brand-bar a:visited { color: #fff; }
+.brand-bar.brand-bar-color-white { background: #000; color: #fff; }
+.brand-bar.brand-bar-color-white a:link, .brand-bar.brand-bar-color-white a:visited { color: #fff; }
+.brand-bar.brand-bar-color-black { background: #fff; color: #000; }
+.brand-bar.brand-bar-color-black a:link, .brand-bar.brand-bar-color-black a:visited { color: #000; }
 
-.brand-bar a:link, .brand-bar a:visited {
-    color: #fff;
-}
+.brand-bar-container { display: flex; flex-direction: row; justify-content: space-between; align-items: center; width: 100%; }
+.brand-bar-container .brand-logo img { width: 100%; max-width: 200px; min-width: 160px; height: auto; display: block; }
+@media screen and (min-width: 768px) { .brand-bar-container .brand-logo img { max-width: 240px; } }
 
-.brand-bar.brand-bar-color-white {
-    background: #000;
-    color: #fff;
-}
+.brand-color-white, .brand-bar-reverse, .brand-bar-dark, .brand-bar-black { color: #fff !important; }
+.brand-color-white a:link, .brand-color-white a:visited, .brand-bar-reverse a:link, .brand-bar-reverse a:visited, .brand-bar-dark a:link, .brand-bar-dark a:visited, .brand-bar-black a:link, .brand-bar-black a:visited { color: #fff !important; }
 
-.brand-bar.brand-bar-color-white a:link, .brand-bar.brand-bar-color-white a:visited {
-    color: #fff;
-}
+.header-wrapper { background: #fff; color: #111111; }
 
-.brand-bar.brand-bar-color-black {
-    background: #fff;
-    color: #000;
-}
+header.ucb { position: relative; display: flex; align-items: center; font-size: 20px; padding: 15px 0; font-weight: 750; font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif; line-height: 1.1; }
+header.ucb .site-name, header.ucb h1.site-name { font-size: 20px; font-weight: 750; font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif; line-height: 1.1; }
+@media screen and (min-width: 768px) { header.ucb, header.ucb .site-name, header.ucb h1.site-name { font-size: 30px; } }
+header.ucb .site-name-wrapper { flex-grow: 1; padding-right: 40px; }
 
-.brand-bar.brand-bar-color-black a:link, .brand-bar.brand-bar-color-black a:visited {
-    color: #000;
-}
+.site-name { padding: 0; margin: 0; }
 
-.brand-bar-container {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-}
-
-.brand-bar-container .brand-logo img {
-    width: 100%;
-    max-width: 200px;
-    min-width: 160px;
-    height: auto;
-    display: block;
-}
-
-@media screen and (min-width: 768px) {
-    .brand-bar-container .brand-logo img {
-        max-width: 240px;
-    }
-}
-
-.brand-color-white, .brand-bar-reverse, .brand-bar-dark, .brand-bar-black {
-    color: #fff !important;
-}
-
-.brand-color-white a:link, .brand-color-white a:visited, .brand-bar-reverse a:link, .brand-bar-reverse a:visited, .brand-bar-dark a:link, .brand-bar-dark a:visited, .brand-bar-black a:link, .brand-bar-black a:visited {
-    color: #fff !important;
-}
-
-.header-wrapper {
-    background: #fff;
-    color: #111111;
-}
-
-header.ucb {
-    position: relative;
-    display: flex;
-    align-items: center;
-    font-size: 20px;
-    padding: 15px 0;
-    font-weight: 750;
-    font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 1.1;
-}
-
-header.ucb .site-name, header.ucb h1.site-name {
-    font-size: 20px;
-    font-weight: 750;
-    font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
-    line-height: 1.1;
-}
-
-@media screen and (min-width: 768px) {
-    header.ucb, header.ucb .site-name, header.ucb h1.site-name {
-        font-size: 30px;
-    }
-}
-
-header.ucb .site-name-wrapper {
-    flex-grow: 1;
-    padding-right: 40px;
-}
-
-.site-name {
-    padding: 0;
-    margin: 0;
-}
-
-.affiliation {
-    text-transform: uppercase;
-    font-size: 50%;
-    padding-top: 5px;
-    font-weight: bold;
-}
-
-.banner-black .header-wrapper .affiliation, .banner-black .header-wrapper .affiliation a:link, .banner-black .header-wrapper .affiliation a:visited, header.ucb.black .affiliation, .affiliation header.ucb.black a:link, .affiliation header.ucb.black a:visited {
-    color: #aaa;
-}
-
-.banner-dark .header-wrapper .affiliation, .banner-dark .header-wrapper .affiliation a:link, .banner-dark .header-wrapper .affiliation a:visited, header.ucb.dark .affiliation, header.ucb.dark .affiliation a:link, header.ucb.dark .affiliation a:visited {
-    color: #9b9b9b;
-}
-
-.banner-white .header-wrapper .affiliation, .banner-white .header-wrapper .affiliation a:link, .banner-white .header-wrapper .affiliation a:visited, header.ucb.white .affiliation, header.ucb.white .affiliation a:link, header.ucb.white .affiliation a:visited {
-    color: #757575;
-}
-
-.banner-light .header-wrapper .affiliation, .banner-light .header-wrapper .affiliation a:link, .banner-light .header-wrapper .affiliation a:visited, header.ucb.light .affiliation, header.ucb.light .affiliation a:link, header.ucb.light .affiliation a:visited {
-    color: #6e6e6e;
-}
-
+.affiliation { text-transform: uppercase; font-size: 50%; padding-top: 5px; font-weight: bold; }
+.banner-black .header-wrapper .affiliation, .banner-black .header-wrapper .affiliation a:link, .banner-black .header-wrapper .affiliation a:visited, header.ucb.black .affiliation, .affiliation header.ucb.black a:link, .affiliation header.ucb.black a:visited { color: #aaa; }
+.banner-dark .header-wrapper .affiliation, .banner-dark .header-wrapper .affiliation a:link, .banner-dark .header-wrapper .affiliation a:visited, header.ucb.dark .affiliation, header.ucb.dark .affiliation a:link, header.ucb.dark .affiliation a:visited { color: #9b9b9b; }
+.banner-white .header-wrapper .affiliation, .banner-white .header-wrapper .affiliation a:link, .banner-white .header-wrapper .affiliation a:visited, header.ucb.white .affiliation, header.ucb.white .affiliation a:link, header.ucb.white .affiliation a:visited { color: #757575; }
+.banner-light .header-wrapper .affiliation, .banner-light .header-wrapper .affiliation a:link, .banner-light .header-wrapper .affiliation a:visited, header.ucb.light .affiliation, header.ucb.light .affiliation a:link, header.ucb.light .affiliation a:visited { color: #6e6e6e; }
 @media screen and (min-width: 800px) {
+    .header-cuscholar { padding: 0px; }
+}
+
+@media screen and (max-width: 768px) {
     .header-cuscholar {
         padding: 0px 0px 0px 15px;
     }

--- a/app/assets/stylesheets/cu_boulder_branding.css
+++ b/app/assets/stylesheets/cu_boulder_branding.css
@@ -1,14 +1,16 @@
 .samvera-cu-brand {
-    width:300px;
+    width: 300px;
     padding: 5px 15px !important;
     height: 35px !important;
 }
+
 .samvera-cu-brand-department {
-    width:300px;
-    clear:both;
-    padding:4px 4px 4px 2px !important;
-    display:block !important;
+    width: 300px;
+    clear: both;
+    padding: 4px 4px 4px 2px !important;
+    display: block !important;
 }
+
 .collection-highlights img {
     height: 60px;
     width: 60px;
@@ -17,8 +19,15 @@
 body.dashboard {
     margin-top: 43px;
 }
-.site-footer {color:white;}
-.ucb-footer p {margin-bottom:2px;}
+
+.site-footer {
+    color: white;
+}
+
+.ucb-footer p {
+    margin-bottom: 2px;
+}
+
 /* * Global styles
 html { box-sizing: border-box; }
 
@@ -38,64 +47,208 @@ a:active { color: #B71C1C; text-decoration-color: rgba(183, 28, 28, 0.65); -webk
     white-space: nowrap !important;
 }
 
-#print-header { display: none; }
+#print-header {
+    display: none;
+}
 
-.banner-white .header-wrapper, header.white { background: #fff; color: #111111; }
-.banner-white .header-wrapper a:link, .banner-white .header-wrapper a:visited, .banner-white .header-wrapper a:hover, header.white a:link, header.white a:visited, header.white a:hover { color: #111111; }
-.banner-white .header-wrapper .menu-toggle button, header.white .menu-toggle button { color: #111111; border-color: rgba(128, 128, 128, 0.5); }
-.banner-white .header-wrapper a.search-toggle:link, .banner-white .header-wrapper a.search-toggle:visited, header.white a.search-toggle:link, header.white a.search-toggle:visited { color: #111111; }
+.banner-white .header-wrapper, header.white {
+    background: #fff;
+    color: #111111;
+}
 
-.banner-light .header-wrapper, header.light { background: #EEEEEE; color: #111111; }
-.banner-light .header-wrapper a:link, .banner-light .header-wrapper a:visited, .banner-light .header-wrapper a:hover, header.light a:link, header.light a:visited, header.light a:hover { color: #111111; }
-.banner-light .header-wrapper .menu-toggle button, header.light .menu-toggle button { color: #111111; border-color: rgba(128, 128, 128, 0.5); }
-.banner-light .header-wrapper a.search-toggle:link, .banner-light .header-wrapper a.search-toggle:visited, header.light a.search-toggle:link, header.light a.search-toggle:visited { color: #111111; }
+.banner-white .header-wrapper a:link, .banner-white .header-wrapper a:visited, .banner-white .header-wrapper a:hover, header.white a:link, header.white a:visited, header.white a:hover {
+    color: #111111;
+}
 
-.banner-dark .header-wrapper, header.dark { background: #424242; color: #fff; }
-.banner-dark .header-wrapper a:link, .banner-dark .header-wrapper a:visited, .banner-dark .header-wrapper a:hover, header.dark a:link, header.dark a:visited, header.dark a:hover { color: #fff; }
-.banner-dark .header-wrapper .menu-toggle button, header.dark .menu-toggle button { color: #fff; border-color: rgba(128, 128, 128, 0.5); }
-.banner-dark .header-wrapper a.search-toggle:link, .banner-dark .header-wrapper a.search-toggle:visited, header.dark a.search-toggle:link, header.dark a.search-toggle:visited { color: #fff; }
+.banner-white .header-wrapper .menu-toggle button, header.white .menu-toggle button {
+    color: #111111;
+    border-color: rgba(128, 128, 128, 0.5);
+}
 
-.banner-black .header-wrapper, header.black { background: #000; color: #fff; }
-.banner-black .header-wrapper a:link, .banner-black .header-wrapper a:visited, .banner-black .header-wrapper a:hover, header.black a:link, header.black a:visited, header.black a:hover { color: #fff; }
-.banner-black .header-wrapper .menu-toggle button, header.black .menu-toggle button { color: #fff; border-color: rgba(128, 128, 128, 0.5); }
-.banner-black .header-wrapper a.search-toggle:link, .banner-black .header-wrapper a.search-toggle:visited, header.black a.search-toggle:link, header.black a.search-toggle:visited { color: #fff; }
+.banner-white .header-wrapper a.search-toggle:link, .banner-white .header-wrapper a.search-toggle:visited, header.white a.search-toggle:link, header.white a.search-toggle:visited {
+    color: #111111;
+}
 
-#branding { position: relative; }
+.banner-light .header-wrapper, header.light {
+    background: #EEEEEE;
+    color: #111111;
+}
+
+.banner-light .header-wrapper a:link, .banner-light .header-wrapper a:visited, .banner-light .header-wrapper a:hover, header.light a:link, header.light a:visited, header.light a:hover {
+    color: #111111;
+}
+
+.banner-light .header-wrapper .menu-toggle button, header.light .menu-toggle button {
+    color: #111111;
+    border-color: rgba(128, 128, 128, 0.5);
+}
+
+.banner-light .header-wrapper a.search-toggle:link, .banner-light .header-wrapper a.search-toggle:visited, header.light a.search-toggle:link, header.light a.search-toggle:visited {
+    color: #111111;
+}
+
+.banner-dark .header-wrapper, header.dark {
+    background: #424242;
+    color: #fff;
+}
+
+.banner-dark .header-wrapper a:link, .banner-dark .header-wrapper a:visited, .banner-dark .header-wrapper a:hover, header.dark a:link, header.dark a:visited, header.dark a:hover {
+    color: #fff;
+}
+
+.banner-dark .header-wrapper .menu-toggle button, header.dark .menu-toggle button {
+    color: #fff;
+    border-color: rgba(128, 128, 128, 0.5);
+}
+
+.banner-dark .header-wrapper a.search-toggle:link, .banner-dark .header-wrapper a.search-toggle:visited, header.dark a.search-toggle:link, header.dark a.search-toggle:visited {
+    color: #fff;
+}
+
+.banner-black .header-wrapper, header.black {
+    background: #000;
+    color: #fff;
+}
+
+.banner-black .header-wrapper a:link, .banner-black .header-wrapper a:visited, .banner-black .header-wrapper a:hover, header.black a:link, header.black a:visited, header.black a:hover {
+    color: #fff;
+}
+
+.banner-black .header-wrapper .menu-toggle button, header.black .menu-toggle button {
+    color: #fff;
+    border-color: rgba(128, 128, 128, 0.5);
+}
+
+.banner-black .header-wrapper a.search-toggle:link, .banner-black .header-wrapper a.search-toggle:visited, header.black a.search-toggle:link, header.black a.search-toggle:visited {
+    color: #fff;
+}
+
+#branding {
+    position: relative;
+}
 
 /* NEW BRANDING */
-.brand-bar { background: #000; color: #fff; padding: 10px 0px; }
-.brand-bar a:link, .brand-bar a:visited { color: #fff; }
-.brand-bar.brand-bar-color-white { background: #000; color: #fff; }
-.brand-bar.brand-bar-color-white a:link, .brand-bar.brand-bar-color-white a:visited { color: #fff; }
-.brand-bar.brand-bar-color-black { background: #fff; color: #000; }
-.brand-bar.brand-bar-color-black a:link, .brand-bar.brand-bar-color-black a:visited { color: #000; }
-
-.brand-bar-container { display: flex; flex-direction: row; justify-content: space-between; align-items: center; width: 100%; }
-.brand-bar-container .brand-logo img { width: 100%; max-width: 200px; min-width: 160px; height: auto; display: block; }
-@media screen and (min-width: 768px) { .brand-bar-container .brand-logo img { max-width: 240px; } }
-
-.brand-color-white, .brand-bar-reverse, .brand-bar-dark, .brand-bar-black { color: #fff !important; }
-.brand-color-white a:link, .brand-color-white a:visited, .brand-bar-reverse a:link, .brand-bar-reverse a:visited, .brand-bar-dark a:link, .brand-bar-dark a:visited, .brand-bar-black a:link, .brand-bar-black a:visited { color: #fff !important; }
-
-.header-wrapper { background: #fff; color: #111111; }
-
-header.ucb { position: relative; display: flex; align-items: center; font-size: 20px; padding: 15px 0; font-weight: 750; font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif; line-height: 1.1; }
-header.ucb .site-name, header.ucb h1.site-name { font-size: 20px; font-weight: 750; font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif; line-height: 1.1; }
-@media screen and (min-width: 768px) { header.ucb, header.ucb .site-name, header.ucb h1.site-name { font-size: 30px; } }
-header.ucb .site-name-wrapper { flex-grow: 1; padding-right: 40px; }
-
-.site-name { padding: 0; margin: 0; }
-
-.affiliation { text-transform: uppercase; font-size: 50%; padding-top: 5px; font-weight: bold; }
-.banner-black .header-wrapper .affiliation, .banner-black .header-wrapper .affiliation a:link, .banner-black .header-wrapper .affiliation a:visited, header.ucb.black .affiliation, .affiliation header.ucb.black a:link, .affiliation header.ucb.black a:visited { color: #aaa; }
-.banner-dark .header-wrapper .affiliation, .banner-dark .header-wrapper .affiliation a:link, .banner-dark .header-wrapper .affiliation a:visited, header.ucb.dark .affiliation, header.ucb.dark .affiliation a:link, header.ucb.dark .affiliation a:visited { color: #9b9b9b; }
-.banner-white .header-wrapper .affiliation, .banner-white .header-wrapper .affiliation a:link, .banner-white .header-wrapper .affiliation a:visited, header.ucb.white .affiliation, header.ucb.white .affiliation a:link, header.ucb.white .affiliation a:visited { color: #757575; }
-.banner-light .header-wrapper .affiliation, .banner-light .header-wrapper .affiliation a:link, .banner-light .header-wrapper .affiliation a:visited, header.ucb.light .affiliation, header.ucb.light .affiliation a:link, header.ucb.light .affiliation a:visited { color: #6e6e6e; }
-@media screen and (min-width: 800px) {
-    .header-cuscholar { padding: 0px; }
+.brand-bar {
+    background: #000;
+    color: #fff;
+    padding: 10px 0px;
 }
-/*# sourceMappingURL=branding.css.map */
-@media screen and (max-width: 768px) {
+
+.brand-bar a:link, .brand-bar a:visited {
+    color: #fff;
+}
+
+.brand-bar.brand-bar-color-white {
+    background: #000;
+    color: #fff;
+}
+
+.brand-bar.brand-bar-color-white a:link, .brand-bar.brand-bar-color-white a:visited {
+    color: #fff;
+}
+
+.brand-bar.brand-bar-color-black {
+    background: #fff;
+    color: #000;
+}
+
+.brand-bar.brand-bar-color-black a:link, .brand-bar.brand-bar-color-black a:visited {
+    color: #000;
+}
+
+.brand-bar-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+}
+
+.brand-bar-container .brand-logo img {
+    width: 100%;
+    max-width: 200px;
+    min-width: 160px;
+    height: auto;
+    display: block;
+}
+
+@media screen and (min-width: 768px) {
+    .brand-bar-container .brand-logo img {
+        max-width: 240px;
+    }
+}
+
+.brand-color-white, .brand-bar-reverse, .brand-bar-dark, .brand-bar-black {
+    color: #fff !important;
+}
+
+.brand-color-white a:link, .brand-color-white a:visited, .brand-bar-reverse a:link, .brand-bar-reverse a:visited, .brand-bar-dark a:link, .brand-bar-dark a:visited, .brand-bar-black a:link, .brand-bar-black a:visited {
+    color: #fff !important;
+}
+
+.header-wrapper {
+    background: #fff;
+    color: #111111;
+}
+
+header.ucb {
+    position: relative;
+    display: flex;
+    align-items: center;
+    font-size: 20px;
+    padding: 15px 0;
+    font-weight: 750;
+    font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 1.1;
+}
+
+header.ucb .site-name, header.ucb h1.site-name {
+    font-size: 20px;
+    font-weight: 750;
+    font-family: "Neue Helvetica W05", "Roboto Condensed", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    line-height: 1.1;
+}
+
+@media screen and (min-width: 768px) {
+    header.ucb, header.ucb .site-name, header.ucb h1.site-name {
+        font-size: 30px;
+    }
+}
+
+header.ucb .site-name-wrapper {
+    flex-grow: 1;
+    padding-right: 40px;
+}
+
+.site-name {
+    padding: 0;
+    margin: 0;
+}
+
+.affiliation {
+    text-transform: uppercase;
+    font-size: 50%;
+    padding-top: 5px;
+    font-weight: bold;
+}
+
+.banner-black .header-wrapper .affiliation, .banner-black .header-wrapper .affiliation a:link, .banner-black .header-wrapper .affiliation a:visited, header.ucb.black .affiliation, .affiliation header.ucb.black a:link, .affiliation header.ucb.black a:visited {
+    color: #aaa;
+}
+
+.banner-dark .header-wrapper .affiliation, .banner-dark .header-wrapper .affiliation a:link, .banner-dark .header-wrapper .affiliation a:visited, header.ucb.dark .affiliation, header.ucb.dark .affiliation a:link, header.ucb.dark .affiliation a:visited {
+    color: #9b9b9b;
+}
+
+.banner-white .header-wrapper .affiliation, .banner-white .header-wrapper .affiliation a:link, .banner-white .header-wrapper .affiliation a:visited, header.ucb.white .affiliation, header.ucb.white .affiliation a:link, header.ucb.white .affiliation a:visited {
+    color: #757575;
+}
+
+.banner-light .header-wrapper .affiliation, .banner-light .header-wrapper .affiliation a:link, .banner-light .header-wrapper .affiliation a:visited, header.ucb.light .affiliation, header.ucb.light .affiliation a:link, header.ucb.light .affiliation a:visited {
+    color: #6e6e6e;
+}
+
+@media screen and (min-width: 800px) {
     .header-cuscholar {
         padding: 0px 0px 0px 15px;
     }

--- a/app/assets/stylesheets/cu_boulder_branding.css.map
+++ b/app/assets/stylesheets/cu_boulder_branding.css.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "cu_boulder_branding.css",
+  "sources": [
+    "cu_boulder_branding.css"
+  ],
+  "sourcesContent": [],
+  "names": [],
+  "mappings": ""
+}

--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -1,0 +1,18 @@
+<%= simple_form_for [main_app, curation_concern], html: { multipart: true, class: 'nav-safety' } do |f| %>
+  <fieldset class="required">
+    <span class="control-label">
+      <%= label_tag 'file_set[title][]', t('.title'), class: "string optional" %>
+    </span>
+    <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control', required: true %>
+  </fieldset>
+
+  <div class="row">
+    <div class="col-md-12 form-actions">
+      <%= f.submit(
+            (curation_concern.persisted? ? t('.save') : t('.attach_to', parent: @presenter.parent.human_readable_type)),
+            class: 'btn btn-primary'
+          ) %>
+      <%= link_to t('.cancel'), parent_path(@presenter.parent), class: 'btn btn-link' %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>Scholar</title>
-    <%= csrf_meta_tags %>
+<head>
+  <title>Scholar</title>
+  <%= csrf_meta_tags %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-  </head>
+  <%= stylesheet_link_tag 'cu_boulder_branding', media: 'all' %>
+  <%= stylesheet_link_tag 'cu_boulder_font', media: 'all' %>
+  <%= stylesheet_link_tag 'openseadragon', media: 'all' %>
+  <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+</head>
 
-  <body>
-    <%= yield %>
-  </body>
+<body>
+<%= yield %>
+</body>
 </html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,12 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
+
+# Add these files to the precompilation
+Rails.application.config.assets.precompile += %w[
+  cu_boulder_font.css
+  cu_boulder_branding.css
+  cu_boulder_branding.css.map
+  openseadragon.css
+  openseadragon/openseadragon.js.map
+]

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,12 +12,3 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w( admin.js admin.css )
-
-# Add these files to the precompilation
-Rails.application.config.assets.precompile += %w[
-  cu_boulder_font.css
-  cu_boulder_branding.css
-  cu_boulder_branding.css.map
-  openseadragon.css
-  openseadragon/openseadragon.js.map
-]

--- a/config/initializers/hacks/edit_permissions_service.rb
+++ b/config/initializers/hacks/edit_permissions_service.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+## CUBL Change:
+# This fixes how FileSetEditForms retrieves the parent work
+Hyrax::EditPermissionsService.class_eval do
+  def self.build_service_object_from(form:, ability:)
+    if form.object.respond_to?(:model) && form.object.model.work?
+      # The provided form object is a work form.
+      new(object: form.object, ability: ability)
+    elsif form.object.respond_to?(:model) && form.object.model.file_set?
+      # The provided form object is a FileSet form. For Valkyrie forms,
+      # Hyrax::Forms::FileSetForm, :in_works_ids is prepopulated onto
+      # the form object itself. For Hyrax::Forms::FileSetEditForm, the
+      # :in_works method is present on the wrapped :model.
+      if form.object.is_a?(Hyrax::Forms::FileSetForm)
+        object_id = form.object.in_works_ids.first
+        new(object: Hyrax.query_service.find_by(id: object_id), ability: ability)
+      else
+        ids = ActiveFedora::SolrService.query("{!field f=member_ids_ssim}#{form.object.model.id}",
+                                              fl: ActiveFedora.id_field)
+                                       .map { |x| x.fetch(ActiveFedora.id_field) }
+        af_work = ActiveFedora::Base.find(ids.first.to_s)
+
+        new(object: af_work, ability: ability)
+      end
+    elsif form.object.file_set?
+      # The provided form object is a FileSet.
+      new(object: form.object.in_works.first, ability: ability)
+    end
+  end
+end

--- a/config/initializers/hacks/file_set_presenter.rb
+++ b/config/initializers/hacks/file_set_presenter.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+## CUBL Change:
+# Modify the fetch_parent_presenter method so that they are fetched using
+# ActiveFedora::SolrService instead of the newer Hyrax::SolrService to force
+# using ActiveFedora data as is since the Wings/Valkyrie versions aren't
+# always compatible in Hyrax v3.x
+Hyrax::FileSetPresenter.class_eval do
+  def fetch_parent_presenter
+    ids = ActiveFedora::SolrService.query("{!field f=member_ids_ssim}#{id}",
+                                          fl: ActiveFedora.id_field)
+                                   .map { |x| x.fetch(ActiveFedora.id_field) }
+
+    Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{id}.") if ids.empty?
+    ids.each do |id|
+      doc = ::SolrDocument.find(id)
+      next if current_ability.can?(:edit, doc)
+      raise WorkflowAuthorizationException if doc.suppressed? && current_ability.can?(:read, doc)
+    end
+
+    Hyrax::PresenterFactory.build_for(ids: ids,
+                                      presenter_class: Hyrax::WorkShowPresenter,
+                                      presenter_args: current_ability).first
+  end
+end

--- a/config/initializers/hacks/file_sets_controller.rb
+++ b/config/initializers/hacks/file_sets_controller.rb
@@ -1,13 +1,39 @@
 # frozen_string_literal: true
 
 ## CUBL Change:
-# This casts ActiveFedora FileSets to their Valkyrie resource form when appropriate because ActiveFedora FileSets aren't
-# handled as well by the Hyrax code
+# Force this controller to use only ActiveFedora resources because of the
+# compatibility issues in Hyrax v3.x between existing ActiveFedora data and
+# Wings/Valkyrie code
 Hyrax::FileSetsController.class_eval do
   before_action :cast_file_set
 
+  # This casts FileSets to their ActiveFedora resources before controller actions
   def cast_file_set
-    return unless @file_set.class == ::FileSet
-    @file_set = @file_set.valkyrie_resource if @file_set.respond_to?(:parent) && @file_set.parent.nil?
+    return unless @file_set.instance_of?(::FileSet)
+
+    @file_set = ActiveFedora::Base.find(@file_set.id.to_s)
+  end
+
+  def parent(file_set: curation_concern)
+    # Return the parent if it has already been found/set
+    if file_set.respond_to?(:parent) && !file_set.parent.nil?
+      return @parent ||= file_set.parent
+    end
+
+    @parent ||=
+      case file_set
+      when Hyrax::Resource
+        # Handle Wings/Valkyrie FileSets
+        Hyrax.query_service.find_parents(resource: file_set).first
+      else
+        # ids = Hyrax::SolrService.query("{!field f=member_ids_ssim}#{file_set.id}",
+        # Retrieve the parent ID(s) of the ActiveFedora FileSet
+        ids = ActiveFedora::SolrService.query("{!field f=member_ids_ssim}#{file_set.id}",
+                                              fl: ActiveFedora.id_field)
+                                       .map { |x| x.fetch(ActiveFedora.id_field) }
+        Hyrax.logger.warn("Couldn't find a parent work for FileSet: #{file_set.id}.") if ids.empty?
+
+        ActiveFedora::Base.find(ids.first.to_s)
+      end
   end
 end

--- a/config/initializers/rsolr_uri_space_fix.rb
+++ b/config/initializers/rsolr_uri_space_fix.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Fix double-encoding of spaces in Solr request params (e.g., the `sort` spec).
+#
+# RSolr::Uri.params_to_solr builds the query string with URI.encode_www_form,
+# which encodes spaces as "+" (application/x-www-form-urlencoded). Faraday then
+# re-encodes that query string when building the URL, turning each "+" into "%2B".
+# Solr decodes "%2B" back to a literal "+", so it receives e.g.,
+#   sort=score+desc,+system_create_dtsi+desc
+# and rejects every search with:
+#   RSolr::Error::Http 400 - "Can't determine a Sort Order (asc or desc) ..."
+#
+# Forcing spaces to "%20" (instead of "+") avoids the bare "+" that Faraday
+# mangles; Solr decodes "%20" to a real space. This affects all sort options
+# (relevance, date uploaded, date modified) since each contains a space.
+#
+# Remove this patch if rsolr/faraday are upgraded to a pairing that no longer
+# double-encodes.
+
+require 'rsolr'
+
+module RSolr
+  module Uri
+    # Re-defines RSolr::Uri.params_to_solr (singleton method; no `super` available).
+    # Identical to rsolr-2.6.0 except the escaped branch replaces "+" with "%20".
+    def self.params_to_solr(params, escape = true)
+      if escape
+        return URI.encode_www_form(
+          params.reject { |k, v| k.to_s.empty? || v.to_s.empty? }
+        ).gsub('+', '%20')
+      end
+
+      mapped = params.map do |k, v|
+        next if v.to_s.empty?
+
+        if v.instance_of?(::Array)
+          params_to_solr(v.map { |x| [k, x] }, false)
+        else
+          "#{k}=#{v}"
+        end
+      end
+      mapped.compact.join('&')
+    end
+  end
+end


### PR DESCRIPTION
1. Fix Hyrax FileSet parent/edit-permissions resolution for AF compatibility

Patch Hyrax 3.x FileSet handling to consistently resolve parent works and
edit permissions through ActiveFedora paths, avoiding Wings/Valkyrie
mismatches with legacy AF-backed data.

- override `Hyrax::EditPermissionsService.build_service_object_from` to
  resolve FileSet parent work via ActiveFedora/Solr when needed
- patch `Hyrax::FileSetPresenter#fetch_parent_presenter` to query parent
  IDs with `ActiveFedora::SolrService`
- patch `Hyrax::FileSetsController` to cast FileSets to AF resources and
  resolve parents via AF lookup
- update FileSet form partial for title/submit/cancel behavior aligned with
  parent presenter usage
- add CU Boulder branding/OpenSeadragon assets to precompile list
- include related styling/layout updates for CU Boulder branding
- include minor container/dependency ignore updates

2. Add patch for rsolr to fix double encoding of spaces for solr searches

Closes #120 